### PR TITLE
Use newer checkout action:

### DIFF
--- a/.github/workflows/prod-backend-cloudrun-docker.yml
+++ b/.github/workflows/prod-backend-cloudrun-docker.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
        # NOTE: Alternative option - authentication via credentials json
       - name: Google Auth

--- a/.github/workflows/prod-directus-cloudrun-docker.yml
+++ b/.github/workflows/prod-directus-cloudrun-docker.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
        # NOTE: Alternative option - authentication via credentials json
       - name: Google Auth

--- a/.github/workflows/prod-frontend-google-cdn.yml
+++ b/.github/workflows/prod-frontend-google-cdn.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
        # NOTE: Alternative option - authentication via credentials json
       - name: Google Auth


### PR DESCRIPTION
Old actions/checkout@v2 is deprecated (it runs on node 12)
Replaced by actions/checkout@v2 which runs on node 16 LTS

I saw the GithubActions runner complain about this